### PR TITLE
Fixed docker issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ robots.txt
 
 /public/css/*
 /public/js/*
+
+/vol_db_hp
+/database/seeds/.NO-SEED
+

--- a/README-with-docker(notworking).md
+++ b/README-with-docker(notworking).md
@@ -1,77 +1,87 @@
 # Heroes Profile
 
- [Heroes Profile](https://alpha.heroesprofile.com/) is an open Heroes of the Storm stat site.  Providing players with Global Hero Statistics, Personal Profile, MMR, Comparisons, Amateur series, and much more.
+[Heroes Profile](https://alpha.heroesprofile.com/) is an open Heroes of the Storm stat site. Providing players with Global Hero Statistics, Personal Profile, MMR, Comparisons, Amateur series, and much more.
 
- This public repository is the site re-write for [Heroes Profile](https://www.heroesprofile.com/) and is not currently in production.
+This public repository is the site re-write for [Heroes Profile](https://www.heroesprofile.com/) and is not currently in production.
 
 # Cloning the Heroes Profile repository
- * `git clone --recursive https://github.com/Heroes-Profile/heroesprofile.git`
- * `cd heroesprofile`
- * `git submodule update --remote`
- * If you have issues getting the seed files to populate in `database/seeds/heroesprofile-seeds/seed-files`, you can pull them directly from https://github.com/Heroes-Profile/heroesprofile-seeds.git
+
+-   `git clone --recursive https://github.com/Heroes-Profile/heroesprofile.git`
+-   `cd heroesprofile`
+-   `git submodule update --remote`
+-   If you have issues getting the seed files to populate in `database/seeds/heroesprofile-seeds/seed-files`, you can pull them directly from https://github.com/Heroes-Profile/heroesprofile-seeds.git
 
 # Docker Setup
 
 Make sure you have docker and docker compose installed. This method will setup separate containers for the `database` and the `app`
 
- * `docker-compose up -d`
- * wait for
-   * database initialisation
-   * data migration and seeding
-   * dependencies (composer + npm) installation
- * `docker-compose logs -f` to check if there are any issues in setup
- * go to http://localhost
+-   `docker-compose up -d`
+-   wait for
+    -   database initialisation
+    -   data migration and seeding
+    -   dependencies (composer + npm) installation
+-   `docker-compose logs -f` to check if there are any issues in setup
+-   go to http://localhost
 
 If you need to get into a command promt for the app
- * `docker-compose run app bash` -- will start a command prompt in a new container
- * `docker-compose exec app bash` -- will attach to an existing container if already running
+
+-   `docker-compose run app bash` -- will start a command prompt in a new container
+-   `docker-compose exec app bash` -- will attach to an existing container if already running
+
+## Troubleshooting
+
+If you have issues with the migration/seeding ensure the database service is fully started and that the volumes have been created. You can fix this by running `docker-compose up database` and waiting for it to be ready before running `docker-compose up app` in a separate terminal. This should only happen if it's your first time running `docker-compose up`.
 
 # Manual Setup
 
- ## Installation
+## Installation
 
- Heroes Profile is a PHP/Laravel and vue.js app. Making use of a MySql database.  Every system has different methods for getting the required dependencies installed so please reference the main tools sites for installation instructions.
+Heroes Profile is a PHP/Laravel and vue.js app. Making use of a MySql database. Every system has different methods for getting the required dependencies installed so please reference the main tools sites for installation instructions.
 
- Laravel - https://laravel.com/
+Laravel - https://laravel.com/
 
- Vue.js - https://vuejs.org/
+Vue.js - https://vuejs.org/
 
- PHP - PHP can be installed in different ways.  If you do not currently have PHP installed, use google to find the best method for you.
- * Increase your local PHP memory_limit var.  We use 1g.  memory_limit = 1G
+PHP - PHP can be installed in different ways. If you do not currently have PHP installed, use google to find the best method for you.
 
- MySQL - MySQL can be installed in different ways.  If you do not currently have MySQL installed, use google to find the best method for you.
+-   Increase your local PHP memory_limit var. We use 1g. memory_limit = 1G
 
- Optional - A visual tool for looking at the database and data is suggested.  MySql Workbench is our preference - https://www.mysql.com/products/workbench/
+MySQL - MySQL can be installed in different ways. If you do not currently have MySQL installed, use google to find the best method for you.
 
+Optional - A visual tool for looking at the database and data is suggested. MySql Workbench is our preference - https://www.mysql.com/products/workbench/
 
- In addition to creating the environment yourself, there are also a lot of different tools that can pull together all the dependencies for you.  Homestead is an example.
+In addition to creating the environment yourself, there are also a lot of different tools that can pull together all the dependencies for you. Homestead is an example.
 
- For windows users, Wampserver64 is a useful tool as it installs the MySql server and php at the same time. https://sourceforge.net/projects/wampserver/
+For windows users, Wampserver64 is a useful tool as it installs the MySql server and php at the same time. https://sourceforge.net/projects/wampserver/
 
- ## Database setup
- * Create the following schemas in your MySql database.   `heroesprofile`, `heroesprofile_brawl`, `heroesprofile_cache`, `heroesprofile_optout`
- * Increase your local mysql max_allowed_packet var.  We use 64M.
+## Database setup
 
- ## Project Setup
- * From the command line, navigate to the heroesprofile repository.
- * Configure `.env` file using `.env.example`
- * Run `composer install`
- * Run `php artisan key:generate` make sure the APP_KEY has this value in the .env file
- * Run `npm install`
- * Run `php artisan migrate`
- * Run `composer dump-autoload`
- * Run `php artisan db:seed`
+-   Create the following schemas in your MySql database. `heroesprofile`, `heroesprofile_brawl`, `heroesprofile_cache`, `heroesprofile_optout`
+-   Increase your local mysql max_allowed_packet var. We use 64M.
 
- ## Running the project
- * From the command line, navigate to the heroesprofile repository.
- * Run `php artisan serve` - spins up the webserver
- * The path to paste into the browser will show up in the command line.
- * From a second command line, navigate to the heroesprofile repository.
- * Run `npm run watch` - watches for any changes to vue and automatically recompiles
+## Project Setup
 
- # Contributing
- All contributions are welcome.  The owners of Heroes Profile reserve the right to include or deny any merge requests from the community.  Also, please try and only create pull requests that contain updates to the specific update you want to make.  Including environment or auto-generated updates to framework code that are not required for your change only complicates making updates.
+-   From the command line, navigate to the heroesprofile repository.
+-   Configure `.env` file using `.env.example`
+-   Run `composer install`
+-   Run `php artisan key:generate` make sure the APP_KEY has this value in the .env file
+-   Run `npm install`
+-   Run `php artisan migrate`
+-   Run `composer dump-autoload`
+-   Run `php artisan db:seed`
 
- If a contribution requires changes to the database, or how the data is grabbed from replays, please log an issue report detailing your need.
+## Running the project
 
- * If backend code from the production site is needed, it can be found in the live_side_code folder of this repository.  If there is code you need that is missing, please create a PR to have that added.
+-   From the command line, navigate to the heroesprofile repository.
+-   Run `php artisan serve` - spins up the webserver
+-   The path to paste into the browser will show up in the command line.
+-   From a second command line, navigate to the heroesprofile repository.
+-   Run `npm run watch` - watches for any changes to vue and automatically recompiles
+
+# Contributing
+
+All contributions are welcome. The owners of Heroes Profile reserve the right to include or deny any merge requests from the community. Also, please try and only create pull requests that contain updates to the specific update you want to make. Including environment or auto-generated updates to framework code that are not required for your change only complicates making updates.
+
+If a contribution requires changes to the database, or how the data is grabbed from replays, please log an issue report detailing your need.
+
+-   If backend code from the production site is needed, it can be found in the live_side_code folder of this repository. If there is code you need that is missing, please create a PR to have that added.

--- a/app.entrypoint.sh
+++ b/app.entrypoint.sh
@@ -40,10 +40,16 @@ php artisan migrate
 
 composer dump-autoload
 
-# Run php artisan db:seed - TODO - make conditional
+FILE=./database/seeds/.NO-SEED
+if [ -d "$FILE" ]; then
+    echo "Database has already been seeded"
+    echo "If you need to re-seed the database, delete ${FILE}"
+else 
+    php artisan db:seed
+    touch ${FILE}
+fi
 
-php artisan db:seed
 
 # Serve app
-
-php /var/www/html/artisan serve --host=0.0.0.0 --port=80
+#  TODO port should be read in from .env
+php /var/www/html/artisan serve --host=0.0.0.0 --port=3000

--- a/database.Dockerfile
+++ b/database.Dockerfile
@@ -1,0 +1,4 @@
+FROM mysql:5
+
+# 999 is the default docker user, this avoids write permission issues with mysql
+RUN mkdir ./vol_db_hp && chown -R 999:999 vol_db_hp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,41 @@
-version: '3'
+version: "3"
 services:
   app:
     image: misterio92/ci-php-node
+    user: "1000:1000"
+    tty: true
     ports:
-      - 80:80
-      - 443:443
+      - 3000:3000
     volumes:
       - ./:/var/www/html
-    restart: always
     networks:
       - heroesprofile
     working_dir: "/var/www/html/"
-    command: "./entrypoint.sh"
+    command: "./app.entrypoint.sh"
+    depends_on:
+      - database
+    expose:
+      - 3000
+
   database:
-    image: mysql:5
+    build:
+      context: .
+      dockerfile: database.Dockerfile
+    user: "mysql:mysql"
+    tty: true
     environment:
-     MYSQL_ROOT_PASSWORD: docker
-     MYSQL_DATABASE: heroesprofile
+      MYSQL_ROOT_PASSWORD: docker
+      MYSQL_DATABASE: heroesprofile
     ports:
       - 3306:3306
     expose:
       - "3306"
     volumes:
-      - vol_db_hp:/var/lib/mysql
+      - ./vol_db_hp:/var/lib/mysql
     restart: always
     networks:
       - heroesprofile
 volumes:
   vol_db_hp:
-
 networks:
   heroesprofile:


### PR DESCRIPTION
Quite a few issues existed with the current docker setup, it just straight up did not work for me from a fresh clone.

`database.Dockerfile` is now used for the database service. This fixes the volume permission issues, as by default volumes are always created by root.

I added a quick and dirty conditional logic for the seeding.

User and groups are assigned to the containers properly, key one being `mysql:mysql` as this was causing write permission problems to the `/var/` data files for mysql.

I removed `restart: always` from the app service, it made it very hard to read output when there was an issue as it just keeps rapidly spamming.

I have no idea why the development server was binding to port 80. You ~~literally can't do that~~ shouldnt do this. If you want to listen on port 80, you use nginx as the web server.

@Zemill Do you want me to make modifications to the README for this before any merging?