### PR TITLE
Reduce query load on talents page

### DIFF
--- a/app/Http/Controllers/Global/GlobalTalentStatsController.php
+++ b/app/Http/Controllers/Global/GlobalTalentStatsController.php
@@ -274,8 +274,8 @@ if (! env('Production')) {
 
             // Map the data back to each build
             foreach ($topBuilds as $build) {
-                $buildKey = $build->level_one . '-' . $build->level_four . '-' . $build->level_seven . '-' .
-                            $build->level_ten . '-' . $build->level_thirteen . '-' . $build->level_sixteen . '-' .
+                $buildKey = $build->level_one.'-'.$build->level_four.'-'.$build->level_seven.'-'.
+                            $build->level_ten.'-'.$build->level_thirteen.'-'.$build->level_sixteen.'-'.
                             $build->level_twenty;
                 $build->buildData = $allBuildData[$buildKey] ?? [
                     'wins' => 0,
@@ -460,12 +460,12 @@ if (! env('Production')) {
                     foreach ($buildLevels as $levels) {
                         $outerQuery->orWhere(function ($q) use ($build, $levels) {
                             $q->where('level_one', $build->level_one)
-                              ->where('level_four', $build->level_four)
-                              ->where('level_seven', $build->level_seven)
-                              ->where('level_ten', $build->level_ten)
-                              ->where('level_thirteen', $levels['thirteen'])
-                              ->where('level_sixteen', $levels['sixteen'])
-                              ->where('level_twenty', $levels['twenty']);
+                                ->where('level_four', $build->level_four)
+                                ->where('level_seven', $build->level_seven)
+                                ->where('level_ten', $build->level_ten)
+                                ->where('level_thirteen', $levels['thirteen'])
+                                ->where('level_sixteen', $levels['sixteen'])
+                                ->where('level_twenty', $levels['twenty']);
                         });
                     }
                 }
@@ -477,14 +477,14 @@ if (! env('Production')) {
         $buildDataMap = [];
         foreach ($query as $row) {
             // Match to the full build (not progressive levels)
-            $buildKey = $row->level_one . '-' . $row->level_four . '-' . $row->level_seven . '-' .
-                        $row->level_ten . '-' . $row->level_thirteen . '-' . $row->level_sixteen . '-' .
+            $buildKey = $row->level_one.'-'.$row->level_four.'-'.$row->level_seven.'-'.
+                        $row->level_ten.'-'.$row->level_thirteen.'-'.$row->level_sixteen.'-'.
                         $row->level_twenty;
 
             // Find which original build this row belongs to by checking if it matches any progressive level
             foreach ($builds as $build) {
-                $fullBuildKey = $build->level_one . '-' . $build->level_four . '-' . $build->level_seven . '-' .
-                                $build->level_ten . '-' . $build->level_thirteen . '-' . $build->level_sixteen . '-' .
+                $fullBuildKey = $build->level_one.'-'.$build->level_four.'-'.$build->level_seven.'-'.
+                                $build->level_ten.'-'.$build->level_thirteen.'-'.$build->level_sixteen.'-'.
                                 $build->level_twenty;
 
                 // Check if this row matches this build's first 4 levels
@@ -502,7 +502,7 @@ if (! env('Production')) {
                     );
 
                     if ($matchesProgressiveLevel) {
-                        if (!isset($buildDataMap[$fullBuildKey])) {
+                        if (! isset($buildDataMap[$fullBuildKey])) {
                             $buildDataMap[$fullBuildKey] = [
                                 'wins' => 0,
                                 'losses' => 0,
@@ -566,8 +566,8 @@ if (! env('Production')) {
                 foreach ($buildStages as $stage) {
                     $query->orWhere(function ($q) use ($stage) {
                         $q->where('level_thirteen', $stage['thirteen'])
-                          ->where('level_sixteen', $stage['sixteen'])
-                          ->where('level_twenty', $stage['twenty']);
+                            ->where('level_sixteen', $stage['sixteen'])
+                            ->where('level_twenty', $stage['twenty']);
                     });
                 }
             })


### PR DESCRIPTION
I noticed that the global talents page is generating a fairly large number of queries for what it's reporting on, e.g. in this example of the regular seed data it's producing 44 queries: 

http://localhost:8000/Global/Talents/Kharazim?timeframe_type=minor&timeframe=2.55.4.91418&game_type=sl&statfilter=win_rate&build_type=Popular&mirror=0
<img width="2302" height="846" alt="image" src="https://github.com/user-attachments/assets/1886646d-0b2e-4308-b534-602136115c3d" />

Many of these are very similar, and could instead be combined. This PR aggregates the fetching of top builds and then getting their performance data to only require 2 queries, which are then deconstructed

<img width="2305" height="1286" alt="image" src="https://github.com/user-attachments/assets/5cbcf066-ac26-4741-8ebb-43f108cc26ee" />

In this example it reduces the number of queries to 21 (of which only 2 are related to build data anymore). This approach saves around `4N - 1` queries per page load, where N is the number of top builds