### PR TITLE
Improve matchup page performance

### DIFF
--- a/app/Http/Controllers/Global/GlobalHeroMatchupStatsController.php
+++ b/app/Http/Controllers/Global/GlobalHeroMatchupStatsController.php
@@ -239,7 +239,7 @@ class GlobalHeroMatchupStatsController extends GlobalsInputValidationController
                 continue;
             }
 
-            if (!isset($existingHeroIds[$hero->id]) && $heroID != $hero->id) {
+            if (! isset($existingHeroIds[$hero->id]) && $heroID != $hero->id) {
                 $notFound[] = $hero;
             }
         }

--- a/app/Services/GlobalDataService.php
+++ b/app/Services/GlobalDataService.php
@@ -28,7 +28,9 @@ use Illuminate\Support\Facades\DB;
 class GlobalDataService
 {
     private $cachedHeroes = null;
+
     private $cachedGameTypes = null;
+
     private $cachedSeasonsData = null;
 
     public function __construct() {}
@@ -280,6 +282,7 @@ class GlobalDataService
         if ($this->cachedGameTypes === null) {
             $this->cachedGameTypes = GameType::orderBy('type_id', 'ASC')->get();
         }
+
         return clone $this->cachedGameTypes;
     }
 
@@ -288,6 +291,7 @@ class GlobalDataService
         if ($this->cachedHeroes === null) {
             $this->cachedHeroes = Hero::orderBy('name', 'ASC')->get();
         }
+
         return clone $this->cachedHeroes;
     }
 
@@ -309,6 +313,7 @@ class GlobalDataService
         if ($this->cachedSeasonsData === null) {
             $this->cachedSeasonsData = SeasonDate::orderBy('id', 'desc')->get();
         }
+
         return clone $this->cachedSeasonsData;
     }
 
@@ -1032,28 +1037,28 @@ class GlobalDataService
             $region,
             $mirror
         ) {
-                $data = GlobalHeroStats::query()
-                    ->join('heroes', 'heroes.id', '=', 'global_hero_stats.hero')
-                    ->select('heroes.name', 'heroes.short_name', 'heroes.id as hero_id', 'global_hero_stats.win_loss', 'heroes.new_role as role')
-                    ->selectRaw('SUM(global_hero_stats.games_played) as games_played')
-                    ->filterByGameVersion($gameVersion)
-                    ->filterByGameType($gameType)
-                    ->filterByLeagueTier($leagueTier)
-                    ->filterByHeroLeagueTier($heroLeagueTier)
-                    ->filterByRoleLeagueTier($roleLeagueTier)
-                    ->filterByGameMap($gameMap)
-                    ->filterByHeroLevel($heroLevel)
-                    ->excludeMirror($mirror)
-                    ->filterByRegion($region)
-                    ->groupBy('global_hero_stats.hero', 'global_hero_stats.win_loss')
-                    ->get();
+            $data = GlobalHeroStats::query()
+                ->join('heroes', 'heroes.id', '=', 'global_hero_stats.hero')
+                ->select('heroes.name', 'heroes.short_name', 'heroes.id as hero_id', 'global_hero_stats.win_loss', 'heroes.new_role as role')
+                ->selectRaw('SUM(global_hero_stats.games_played) as games_played')
+                ->filterByGameVersion($gameVersion)
+                ->filterByGameType($gameType)
+                ->filterByLeagueTier($leagueTier)
+                ->filterByHeroLeagueTier($heroLeagueTier)
+                ->filterByRoleLeagueTier($roleLeagueTier)
+                ->filterByGameMap($gameMap)
+                ->filterByHeroLevel($heroLevel)
+                ->excludeMirror($mirror)
+                ->filterByRegion($region)
+                ->groupBy('global_hero_stats.hero', 'global_hero_stats.win_loss')
+                ->get();
 
-                $sorted = $data->sortBy(function ($item) {
-                    return [$item->name, $item->win_loss];
-                })->values();
+            $sorted = $data->sortBy(function ($item) {
+                return [$item->name, $item->win_loss];
+            })->values();
 
-                return $this->combineData($sorted);
-            });
+            return $this->combineData($sorted);
+        });
 
         return $data;
     }


### PR DESCRIPTION
Had a quick look at the matchup page's performance and notices a couple easy improvements

- Caching GlobalDataService functions at the request level. This prevents both reaching out to the database repeatedly, and reconstructing models repeatedly
  - Note that this _might_ break things if there are changes by reference going on, I did not see them in code/while clicking around but I did not do an exhaustive check
- Cache keys were being constructed with the result of a database query, while they could just be using the input to that database query instead (given the relation should be one-to-one)
- getAllHeroesGlobalWinRates was doing a group by & sort in the same query which was causing the use of a temporary table & filesort to generate the response. Often this cannot be avoided with this kind of query, but because the result is getting grouped by hero/win_loss anyway there can only be 180 responses (number of heroes * 2), so it's substantially faster to do the sorting in PHP code instead, which avoids the temporary table & filesort in MySQL
- getHeroMatchupData had a few nested loops running in O(n * m), those can be optimized a little to be O(n)

With testing data this ends up being ~33% faster over 30 requests (55.78ms vs 37.54ms), but I think this might actually result in a bigger performance improvement with prod data because of the sorting optimization with a larger dataset

Before
<img width="2292" height="1044" alt="image" src="https://github.com/user-attachments/assets/586ceec3-7419-4dd3-a1d4-ad2f97be6c01" />

After
<img width="2304" height="1246" alt="image" src="https://github.com/user-attachments/assets/a52619d2-41a4-458a-88f6-d589ce5d8d30" />
