### PR TITLE
Fix global seeders database connection

### DIFF
--- a/database/seeders/GlobalCompositionsSeeder.php
+++ b/database/seeders/GlobalCompositionsSeeder.php
@@ -10020,7 +10020,7 @@ class GlobalCompositionsSeeder extends Seeder
         ];
 
         foreach ($data as $row) {
-            DB::table('global_compositions')->insert([
+            DB::connection('heroesprofile_globals')->table('global_compositions')->insert([
                 'global_compositions_id' => $row[0],
                 'game_version' => $row[1],
                 'game_type' => $row[2],

--- a/database/seeders/GlobalHeroMatchupsAllySeeder.php
+++ b/database/seeders/GlobalHeroMatchupsAllySeeder.php
@@ -10016,7 +10016,7 @@ class GlobalHeroMatchupsAllySeeder extends Seeder
         ];
 
         foreach ($data as $row) {
-            DB::table('global_hero_matchups_ally')->insert([
+            DB::connection('heroesprofile_globals')->table('global_hero_matchups_ally')->insert([
                 'global_hero_matchups_ally_id' => $row[0],
                 'game_version' => $row[1],
                 'game_type' => $row[2],

--- a/database/seeders/GlobalHeroMatchupsEnemyTableSeeder.php
+++ b/database/seeders/GlobalHeroMatchupsEnemyTableSeeder.php
@@ -10013,7 +10013,7 @@ class GlobalHeroMatchupsEnemyTableSeeder extends Seeder
         ];
 
         foreach ($data as $row) {
-            DB::table('global_hero_matchups_enemy')->insert([
+            DB::connection('heroesprofile_globals')->table('global_hero_matchups_enemy')->insert([
                 'global_hero_matchups_enemy_id' => $row[0],
                 'game_version' => $row[1],
                 'game_type' => $row[2],

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -27,10 +27,16 @@ This guide helps you set up Heroes Profile for local development using Docker Co
     Sometimes seeders take awhile or use a lot of memory to run and can cause the
     seeding process to stop early. If this occurs you can either manually comment
     out seeders that have completed and run again, or attempt to increase memory
-    usage and/or execution timeout.  E.g
+    usage and/or execution timeout. E.g.
 
     ```bash
     docker compose exec app php -d memory_limit=2G -d max_execution_time=0 artisan db:seed
+    ```
+
+    You can also disable PHP's memory limit for the seeding command:
+
+    ```bash
+    docker compose exec app php -d memory_limit=-1 artisan db:seed
     ```
 
     NOTE:  The data provided in the seeders is not complete.


### PR DESCRIPTION
I had to do this to seed the DB locally. Without it, I was getting this error:

```
❯ docker compose exec app php artisan db:seed

   INFO  Seeding database.

  Database\Seeders\AwardsTableSeeder ....................................................................................................... RUNNING
  Database\Seeders\AwardsTableSeeder .................................................................................................... 49 ms DONE

  Database\Seeders\BattletagsTableSeeder ................................................................................................... RUNNING
  Database\Seeders\BattletagsTableSeeder ............................................................................................ 27,507 ms DONE

  Database\Seeders\CompositionsTableSeeder ................................................................................................. RUNNING
  Database\Seeders\CompositionsTableSeeder ............................................................................................. 258 ms DONE

  Database\Seeders\GameTypesSeeder ......................................................................................................... RUNNING
  Database\Seeders\GameTypesSeeder ...................................................................................................... 10 ms DONE

  Database\Seeders\GlobalCompositionsSeeder ................................................................................................ RUNNING

   Illuminate\Database\QueryException

  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'heroesprofile.global_compositions' doesn't exist (Connection: heroesprofile, SQL: insert into `global_compositions` (`global_compositions_id`, `game_version`, `game_type`, `league_tier`, `hero_league_tier`, `role_league_tier`, `game_map`, `hero_level`, `composition_id`, `hero`, `mirror`, `region`, `win_loss`, `games_played`) values (185952813, 2.55.4.91418, 5, 0, 0, 0, 1, 1, 1, 16, 0, 2, 1, 2))

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:829
    825▕                     $this->getName(), $query, $this->prepareBindings($bindings), $e
    826▕                 );
    827▕             }
    828▕
  ➜ 829▕             throw new QueryException(
    830▕                 $this->getName(), $query, $this->prepareBindings($bindings), $e
    831▕             );
    832▕         }
    833▕     }

      +6 vendor frames

  7   database/seeders/GlobalCompositionsSeeder.php:10023
      Illuminate\Database\Query\Builder::insert()
      +8 vendor frames

  16  database/seeders/DatabaseSeeder.php:14
      Illuminate\Database\Seeder::call("Database\Seeders\GlobalCompositionsSeeder")
```

The seeding was also crashing presumably because of the memory issue as documented and running it with `memory_limit=-1` didn't crash, so I documented that as well.