### PR TITLE
Bug fixes and hero filter pre-selection on match history

### DIFF
--- a/app/Http/Controllers/Player/PlayerMatchHistory.php
+++ b/app/Http/Controllers/Player/PlayerMatchHistory.php
@@ -57,6 +57,7 @@ class PlayerMatchHistory extends Controller
             'gametypedefault' => $gametypedefault, // $this->globalDataService->getGameTypeDefault('multi'), //Removing user defined setting.  Doesnt make sense to me not to show ALL data for player profile pages to start
             'patreon' => $this->globalDataService->checkIfSiteFlair($blizz_id, $region),
             'showcustomgames' => $showcustomgames,
+            'urlparameters' => $request->query(),
         ]);
     }
 

--- a/app/Http/Controllers/SingleMatchController.php
+++ b/app/Http/Controllers/SingleMatchController.php
@@ -500,6 +500,10 @@ class SingleMatchController extends Controller
         });
         $groupedData = array_values($groupedData->toArray());
 
+        if (empty($groupedData)) {
+            return response()->json(['status' => 'Replay data not found'], 404);
+        }
+
         return $groupedData[0];
     }
 
@@ -951,14 +955,14 @@ class SingleMatchController extends Controller
                 'team_zero_ban_data' => [
                     'team_data' => $team_names['team_one'],
                     'name' => $teamOneFromPlayers,
-                    'map_ban_one' => $result->team_0_map_ban != 0 ? $maps[$result->team_0_map_ban] : null,
-                    'map_ban_two' => $result->team_0_map_ban_2 != 0 ? $maps[$result->team_0_map_ban_2] : null,
+                    'map_ban_one' => isset($maps[$result->team_0_map_ban]) ? $maps[$result->team_0_map_ban] : null,
+                    'map_ban_two' => isset($maps[$result->team_0_map_ban_2]) ? $maps[$result->team_0_map_ban_2] : null,
                 ],
                 'team_one_ban_data' => [
                     'team_data' => $team_names['team_two'],
                     'name' => $teamTwoFromPlayers,
-                    'map_ban_one' => $result->team_1_map_ban != 0 ? $maps[$result->team_1_map_ban] : null,
-                    'map_ban_two' => $result->team_1_map_ban_2 != 0 ? $maps[$result->team_1_map_ban_2] : null,
+                    'map_ban_one' => isset($maps[$result->team_1_map_ban]) ? $maps[$result->team_1_map_ban] : null,
+                    'map_ban_two' => isset($maps[$result->team_1_map_ban_2]) ? $maps[$result->team_1_map_ban_2] : null,
                 ],
             ];
         }
@@ -967,15 +971,15 @@ class SingleMatchController extends Controller
             $team_zero_ban_data = [
                 'team_data' => $team_zero_data,
                 'name' => $team_zero_data->team_name,
-                'map_ban_one' => $result->team_0_map_ban != 0 ? $maps[$result->team_0_map_ban] : null,
-                'map_ban_two' => $result->team_0_map_ban_2 != 0 ? $maps[$result->team_0_map_ban_2] : null,
+                'map_ban_one' => isset($maps[$result->team_0_map_ban]) ? $maps[$result->team_0_map_ban] : null,
+                'map_ban_two' => isset($maps[$result->team_0_map_ban_2]) ? $maps[$result->team_0_map_ban_2] : null,
             ];
         } else {
             $team_zero_ban_data = [
                 'team_data' => $team_one_data,
                 'name' => $team_one_data->team_name,
-                'map_ban_one' => $result->team_1_map_ban != 0 ? $maps[$result->team_1_map_ban] : null,
-                'map_ban_two' => $result->team_1_map_ban_2 != 0 ? $maps[$result->team_1_map_ban_2] : 0,
+                'map_ban_one' => isset($maps[$result->team_1_map_ban]) ? $maps[$result->team_1_map_ban] : null,
+                'map_ban_two' => isset($maps[$result->team_1_map_ban_2]) ? $maps[$result->team_1_map_ban_2] : null,
             ];
         }
 
@@ -983,15 +987,15 @@ class SingleMatchController extends Controller
             $team_one_ban_data = [
                 'team_data' => $team_one_data,
                 'name' => $team_one_data->team_name,
-                'map_ban_one' => $result->team_1_map_ban != 0 ? $maps[$result->team_1_map_ban] : null,
-                'map_ban_two' => $result->team_1_map_ban_2 != 0 ? $maps[$result->team_1_map_ban_2] : null,
+                'map_ban_one' => isset($maps[$result->team_1_map_ban]) ? $maps[$result->team_1_map_ban] : null,
+                'map_ban_two' => isset($maps[$result->team_1_map_ban_2]) ? $maps[$result->team_1_map_ban_2] : null,
             ];
         } else {
             $team_one_ban_data = [
                 'team_data' => $team_zero_data,
                 'name' => $team_zero_data->team_name,
-                'map_ban_one' => $result->team_0_map_ban != 0 ? $maps[$result->team_0_map_ban] : null,
-                'map_ban_two' => $result->team_0_map_ban_2 != 0 ? $maps[$result->team_0_map_ban_2] : null,
+                'map_ban_one' => isset($maps[$result->team_0_map_ban]) ? $maps[$result->team_0_map_ban] : null,
+                'map_ban_two' => isset($maps[$result->team_0_map_ban_2]) ? $maps[$result->team_0_map_ban_2] : null,
             ];
         }
 

--- a/app/Services/CloudTasksDispatcher.php
+++ b/app/Services/CloudTasksDispatcher.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use Google\ApiCore\ApiException;
 use Google\Cloud\Tasks\V2\Client\CloudTasksClient;
 use Google\Cloud\Tasks\V2\CreateTaskRequest;
 use Google\Cloud\Tasks\V2\HttpMethod;
@@ -60,7 +61,7 @@ class CloudTasksDispatcher
                 ]);
 
                 return;
-            } catch (\Google\ApiCore\ApiException $e) {
+            } catch (ApiException $e) {
                 $lastException = $e;
                 if ($attempt < 3) {
                     usleep(250000 * $attempt); // 250ms, 500ms

--- a/app/Services/CloudTasksDispatcher.php
+++ b/app/Services/CloudTasksDispatcher.php
@@ -49,11 +49,25 @@ class CloudTasksDispatcher
             'task' => $task,
         ]);
 
-        $client->createTask($request);
+        $lastException = null;
+        for ($attempt = 1; $attempt <= 3; $attempt++) {
+            try {
+                $client->createTask($request);
+                Log::info('Cloud Task enqueued for global query', [
+                    'job_id' => $jobId,
+                    'queue' => $queue,
+                    'attempt' => $attempt,
+                ]);
 
-        Log::info('Cloud Task enqueued for global query', [
-            'job_id' => $jobId,
-            'queue' => $queue,
-        ]);
+                return;
+            } catch (\Google\ApiCore\ApiException $e) {
+                $lastException = $e;
+                if ($attempt < 3) {
+                    usleep(250000 * $attempt); // 250ms, 500ms
+                }
+            }
+        }
+
+        throw $lastException;
     }
 }

--- a/app/Services/GlobalQueryService.php
+++ b/app/Services/GlobalQueryService.php
@@ -61,7 +61,17 @@ class GlobalQueryService
             'status' => 'pending',
         ], self::STATUS_TTL_SECONDS);
 
-        app(CloudTasksDispatcher::class)->dispatch($jobId);
+        try {
+            app(CloudTasksDispatcher::class)->dispatch($jobId);
+        } catch (\Throwable $e) {
+            $cache->forget($this->jobKey($jobId));
+            $cache->forget($cacheIndexKey);
+            Log::error('Failed to enqueue Cloud Task after retries', [
+                'job_id' => $jobId,
+                'error' => $e->getMessage(),
+            ]);
+            throw $e;
+        }
 
         return $this->withBypassHeader($this->acceptedResponse($jobId, 'pending'), $bypassCache);
     }

--- a/resources/js/components/Player/PlayerMatchHistory.vue
+++ b/resources/js/components/Player/PlayerMatchHistory.vue
@@ -2,14 +2,16 @@
   <div>
     <page-heading  :heading="'Match History'" :battletag="battletag" :region="region" :blizzid="blizzid" :regionstring="regionsmap[region]" :isPatreon="isPatreon" :isOwner="isOwner"></page-heading>
 
-    <filters 
-      :onFilter="filterData" 
-      :filters="filters" 
+    <filters
+      :onFilter="filterData"
+      :filters="filters"
       :isLoading="isLoading"
       :gametypedefault="gametype"
       :minimumgamesdefault="'0'"
       :includehero="true"
       :includerole="true"
+      :heroinput="getHeroID()"
+      :roleinput="role"
       :includegametypefull="showcustomgames ? false : true"
       :includegametypefullcustom="showcustomgames"
       :includeseason="true"
@@ -147,6 +149,10 @@ export default {
     playermatchtablestyle: {
       type: [String, Boolean]
     },
+    urlparameters: {
+      type: Object,
+      default: () => ({}),
+    },
   },
   data(){
     return {
@@ -166,6 +172,15 @@ export default {
   },
   created(){
     this.gametype = this.gametypedefault;
+
+    if (this.urlparameters) {
+      if (this.urlparameters['hero']) {
+        this.hero = this.urlparameters['hero'];
+      }
+      if (this.urlparameters['role']) {
+        this.role = this.urlparameters['role'];
+      }
+    }
   },
   mounted() {
     if(this.playerloadsetting == null || this.playerloadsetting == true || this.playerloadsetting == "true"){
@@ -214,7 +229,7 @@ export default {
           region: this.region,
           game_type: this.gametype,
           role: this.role,
-          hero: this.hero,
+          hero: this.getHeroID(),
           game_map: this.gamemap,
           pagination_page: page,
           season: this.season,
@@ -240,6 +255,13 @@ export default {
         });
       }
     },
+    getHeroID() {
+      if (this.hero) {
+        const match = this.filters.heroes.find(h => h.name === this.hero);
+        return match ? match.code : null;
+      }
+      return null;
+    },
     cancelAxiosRequest() {
       if (this.cancelTokenSource) {
         this.cancelTokenSource.cancel('Request canceled by user');
@@ -248,6 +270,7 @@ export default {
     filterData(filteredData){
       this.role = filteredData.single["Role"] ? filteredData.single["Role"] : null;
       this.hero = filteredData.single.Heroes ? filteredData.single.Heroes : null;
+      this.hero = this.hero ? this.filters.heroes.find(h => h.code === this.hero)?.name : null;
       this.season = filteredData.single.Season ? filteredData.single.Season : null;
       this.gametype = filteredData.multi["Game Type"] ? Array.from(filteredData.multi["Game Type"]) : this.gametype;
       this.gamemap = filteredData.multi.Map ? Array.from(filteredData.multi.Map) : null;

--- a/resources/views/Player/matchHistory.blade.php
+++ b/resources/views/Player/matchHistory.blade.php
@@ -15,6 +15,7 @@
     :regionsmap="{{ json_encode($bladeGlobals['regions']) }}"
     :is-patreon="{{ json_encode($patreon) }}"
     :patreon-user="{{ json_encode(session('patreonSubscriberAdFree')) }}"
+    :urlparameters="{{ json_encode($urlparameters) }}"
   >  
   </player-match-history>
 @endsection


### PR DESCRIPTION
## Summary

- **SingleMatchController**: Return 404 JSON response when replay data is not found instead of crashing on empty array key 0; fix Undefined array key in getMapBans() by replacing != 0 guards with isset() checks on all map ban lookups to handle empty string DB values in PHP 8
- **CloudTasksDispatcher / GlobalQueryService**: Add retry logic (3 attempts, 250ms/500ms backoff) for transient Google Cloud Tasks UNAVAILABLE errors; clean up orphaned pending job cache entries if dispatch fails after all retries to prevent stuck-pending state
- **PlayerMatchHistory**: Fix issue #1324 - hero filter not pre-selecting when navigating from a player hero stats page via ?hero= URL param. Follows the established urlparameters prop pattern used by GlobalHeroStats (controller passes request->query() to blade, blade forwards as prop, Vue reads in created(), getHeroID() converts name to ID for the filter dropdown and API calls)

## Test plan

- [x] Load a single match page for a replay with no player data - should return 404, not 500
- [x] Load an esport match with empty string map ban values - should render without error
- [x] Navigate from a player hero stats page to match history via View Match History - hero dropdown should be pre-selected and results filtered to that hero
- [x] Changing the hero filter manually and clicking Filter should work correctly
- [x] Global stats pages with async queries should recover gracefully from transient Cloud Tasks outages