### PR TITLE
Redesign settings page with tabbed sidebar layout

### DIFF
--- a/resources/js/components/Profile/ProfileSettings.vue
+++ b/resources/js/components/Profile/ProfileSettings.vue
@@ -1,232 +1,248 @@
 <template>
-  <div v-if="!isLoading" class=" mx-auto max-w-[700px]  bg-lighten rounded-lg mt-[10vh]">
-    <h1 v-if="settingsSaved" class="text-center text">Settings Saved</h1>
-    <h1 class="mb-4 bg-teal p-4 rounded-t-lg">Global Page Settings</h1>
-    <div class="flex items-center flex-wrap justify-start p-4">
-      <div class="flex  justify-center">
+  <div>
+  <page-heading :heading="'Settings'"></page-heading>
+  <div class="relative flex mx-auto w-full max-w-[1200px] mt-[2vh] h-[85vh]">
+    <div v-if="isLoading" class="absolute inset-0 z-50 rounded-lg overflow-hidden">
+      <loading-component :textoverride="true">Saving...</loading-component>
+    </div>
 
-        <div class="flex-col  border-white border-r-[1px] px-4">
-          <div class=" ">
-            <h3>Default Multi-Select Game Type:</h3> 
-            <multi-select-filter
-              :values="this.filters.game_types_full" 
-              :text="'Game Type'" 
-              @dropdown-closed="saveSettings()" 
-              @input-changed="handleInputChange" 
-              :defaultValue="usermultigametype"
-              :trackclosure="true"
-            >
-            </multi-select-filter>
+    <!-- Left sidebar -->
+    <div class="w-[180px] shrink-0 bg-lighten rounded-l-lg flex flex-col">
+      <nav class="flex flex-col pt-4">
+        <button
+          v-for="tab in tabs"
+          :key="tab.key"
+          @click="activeTab = tab.key"
+          class="text-left px-6 py-4 text-sm font-medium transition-colors"
+          :class="activeTab === tab.key ? 'bg-teal text-white' : 'text-gray-300 hover:bg-gray-700'"
+        >
+          {{ tab.label }}
+        </button>
+      </nav>
+    </div>
+
+    <!-- Right panel -->
+    <div class="flex-1 bg-lighten rounded-r-lg border-l border-gray-600 overflow-y-auto">
+      <transition name="fade">
+        <div v-if="settingsSaved" class="bg-teal text-white text-center py-2 text-sm rounded-tr-lg">
+          Settings Saved
+        </div>
+      </transition>
+
+      <!-- General -->
+      <div v-if="activeTab === 'general'" class="p-8">
+        <h2 class="text-xl font-bold mb-6 text-teal">General</h2>
+        <div class="space-y-6">
+          <div>
+            <h3 class="mb-2">Table Style</h3>
+            <tab-button tab1text="Light" tab2text="Dark" :ignoreclick="true" @tab-click="darkmodesetting" :overridedefaultside="darkmode"></tab-button>
           </div>
-          <div class="">
-            <h3>Default Build Type</h3> 
-            <!-- Talent build Type -->
-            <single-select-filter 
-              :values="filters.talent_build_types" 
-              :text="'Talent Build Type'" 
-              @dropdown-closed="saveSettings()" 
-              @input-changed="handleInputChange" 
-              :defaultValue="talentBuildType"
+          <div>
+            <h3 class="mb-1">Account Visibility</h3>
+            <p class="text-sm text-gray-400 mb-3">Control whether your profile is visible to other users.</p>
+            <single-select-filter
+              :values="privateOptions"
+              :text="'Account Visibility'"
+              @dropdown-closed="setAccountVisbility()"
+              @input-changed="handleInputChange"
+              :defaultValue="accountVisibility"
               :trackclosure="true"
-            >
-            </single-select-filter>
+            ></single-select-filter>
           </div>
         </div>
+      </div>
 
-        <div class="px-4">
-          <div class="">
-            <h3>Show Advanced Filtering options:</h3> 
-            <single-select-filter 
-              :values="advancedfilteringoptions" 
-              :text="'Advanced Filtering'" 
-              @dropdown-closed="saveSettings()" 
-              @input-changed="handleInputChange" 
-              :defaultValue="advancedfiltering"
-              :trackclosure="true"
-
-            >
-            </single-select-filter>
+      <!-- Global Pages -->
+      <div v-if="activeTab === 'global'" class="p-8">
+        <h2 class="text-xl font-bold mb-6 text-teal">Global Pages</h2>
+        <div class="space-y-6">
+          <div>
+            <h3 class="mb-2">Default Multi-Select Game Type</h3>
+            <div class="w-fit">
+              <multi-select-filter
+                :values="filters.game_types_full"
+                :text="'Game Type'"
+                @dropdown-closed="saveSettings()"
+                @input-changed="handleInputChange"
+                :defaultValue="usermultigametype"
+                :trackclosure="true"
+              ></multi-select-filter>
+            </div>
           </div>
-          <div class="">
-            <h3>Default Game Type:</h3> 
+          <div>
+            <h3 class="mb-2">Default Single Game Type</h3>
             <single-select-filter
-              :values="this.filters.game_types_full" 
-              :text="'Game Type'" 
-              @dropdown-closed="saveSettings()" 
-              @input-changed="handleInputChange" 
+              :values="filters.game_types_full"
+              :text="'Game Type'"
+              @dropdown-closed="saveSettings()"
+              @input-changed="handleInputChange"
               :defaultValue="usergametype"
               :trackclosure="true"
-            >
-            </single-select-filter>
+            ></single-select-filter>
+          </div>
+          <div>
+            <h3 class="mb-2">Default Build Type</h3>
+            <single-select-filter
+              :values="filters.talent_build_types"
+              :text="'Talent Build Type'"
+              @dropdown-closed="saveSettings()"
+              @input-changed="handleInputChange"
+              :defaultValue="talentBuildType"
+              :trackclosure="true"
+            ></single-select-filter>
+          </div>
+          <div>
+            <h3 class="mb-2">Show Advanced Filtering Options</h3>
+            <single-select-filter
+              :values="advancedfilteringoptions"
+              :text="'Advanced Filtering'"
+              @dropdown-closed="saveSettings()"
+              @input-changed="handleInputChange"
+              :defaultValue="advancedfiltering"
+              :trackclosure="true"
+            ></single-select-filter>
           </div>
         </div>
       </div>
 
-        <div class="px-4 mt-4">
-          <h3>Table Style:</h3>
-          <tab-button tab1text="Light" :ignoreclick="true" tab2text="Dark" @tab-click="darkmodesetting" :overridedefaultside="darkmode"> </tab-button>
-        </div>
-
-
-
-    
-
-  
-
-    </div>
-    <h1 class="mb-4 bg-teal p-4">Player Stat Settings</h1>
-
-    <div class="flex items-stretch gap-10 p-4">
-      <div class="flex-col  border-white border-r-[1px] px-4">
-              
-        <div class="">
-          <h3>Player Match History Style</h3> 
-          <tab-button tab1text="Table" :ignoreclick="true" tab2text="Compact" @tab-click="playermatchhistorystylesetting" :overridedefaultside="playerhistorytable"> </tab-button>
-        </div>
-      </div>
-
-      <div class="flex-col  border-white px-4">
-              
-        <div class="">
-            <h3>Default HP MMR Breakdown Game Type:</h3> 
+      <!-- Player -->
+      <div v-if="activeTab === 'player'" class="p-8">
+        <h2 class="text-xl font-bold mb-6 text-teal">Player</h2>
+        <div class="space-y-6">
+          <div>
+            <h3 class="mb-2">Match History Style</h3>
+            <tab-button tab1text="Table" tab2text="Compact" :ignoreclick="true" @tab-click="playermatchhistorystylesetting" :overridedefaultside="playerhistorytable"></tab-button>
+          </div>
+          <div>
+            <h3 class="mb-2">Default HP MMR Breakdown Game Type</h3>
             <single-select-filter
-              :values="this.filters.game_types_full" 
-              :text="'HP MMR Game Type'" 
-              @dropdown-closed="saveSettings()" 
-              @input-changed="handleInputChange" 
+              :values="filters.game_types_full"
+              :text="'HP MMR Game Type'"
+              @dropdown-closed="saveSettings()"
+              @input-changed="handleInputChange"
               :defaultValue="mmrplayerusergametype"
               :trackclosure="true"
-            >
-            </single-select-filter>
+            ></single-select-filter>
           </div>
-      </div>
-
-
-    </div>
-     
-
-        <div class="max-w-[50%] border-r-[1px] px-4 border-white">
-          <h3 class="mb-auto">Player data initial load style</h3>
-          <single-select-filter 
-            :values="playerdataloadstyles" 
-            :text="'Player Load'" 
-            @dropdown-closed="saveSettings()" 
-            @input-changed="handleInputChange" 
-            :defaultValue="playerload"
-            :trackclosure="true"
-            >
-          </single-select-filter>
+          <div>
+            <h3 class="mb-2">Player Data Initial Load Style</h3>
+            <single-select-filter
+              :values="playerdataloadstyles"
+              :text="'Player Load'"
+              @dropdown-closed="saveSettings()"
+              @input-changed="handleInputChange"
+              :defaultValue="playerload"
+              :trackclosure="true"
+            ></single-select-filter>
+          </div>
+          <div>
+            <h3 class="mb-2">Show Custom Games (Match History only)</h3>
+            <single-select-filter
+              :values="showcustomgamesoptions"
+              :text="'Show Custom Games'"
+              @dropdown-closed="saveSettings()"
+              @input-changed="handleInputChange"
+              :defaultValue="customgames"
+              :trackclosure="true"
+            ></single-select-filter>
+          </div>
         </div>
+      </div>
 
-
-        <div class="max-w-[50%] border-r-[1px] px-4 border-white">
-          <h3 class="mb-auto">Show custom games.  Match History page only</h3>
-          <single-select-filter 
-            :values="showcustomgames" 
-            :text="'Show Custom Games'" 
-            @dropdown-closed="saveSettings()" 
-            @input-changed="handleInputChange" 
-            :defaultValue="customgames"
-            :trackclosure="true"
-            >
-          </single-select-filter>
+      <!-- Connections -->
+      <div v-if="activeTab === 'connections'" class="p-8">
+        <h2 class="text-xl font-bold mb-6 text-teal">Connections</h2>
+        <div class="space-y-8">
+          <div class="">
+            <h3 class="mb-1">Patreon</h3>
+            <p class="text-sm text-gray-400 mb-3">Link your Patreon account to unlock supporter features.</p>
+            <div class="flex items-center gap-4">
+              <span v-if="user.patreon_account" class="bg-teal px-3 py-1 rounded text-sm">Connected</span>
+              <custom-button
+                v-if="!user.patreon_account"
+                :href="'/authenticate/patreon'"
+                text="Login with Patreon"
+                alt="Login with Patreon"
+                size="medium"
+                color="blue"
+              ></custom-button>
+              <custom-button
+                v-if="user.patreon_account"
+                :ignoreclick="true"
+                text="Remove Patreon"
+                alt="Remove Patreon"
+                size="medium"
+                color="red"
+                @click="removePatreon()"
+              ></custom-button>
+            </div>
+          </div>
         </div>
-
-
-
-
-
-
-    <h1 class="mb-4 bg-teal p-4">Profile Settings</h1>
-
-    <div class="flex items-stretch gap-10 p-4">
-      <div class="max-w-[50%] border-r-[1px] px-4 border-white">
-        <h3 class="mb-auto">Swap account between private and not private </h3>
-        <single-select-filter 
-          :values="privateOptions" 
-          :text="'Account Visibility'" 
-          @dropdown-closed="setAccountVisbility()" 
-          @input-changed="handleInputChange" 
-          :defaultValue="accountVisibility"
-          :trackclosure="true"
-          >
-        </single-select-filter>
       </div>
-
-
-
-      <div>
-        <h3 class="mb-auto">Link Patreon: <span class="bg-teal px-2"  v-if="this.user.patreon_account">Connected</span></h3>
-        <custom-button class="ml-auto mt-4" v-if="!this.user.patreon_account" :href="'/authenticate/patreon'" :text="'Login with Patreon'" :alt="'Login with Patreon'"  :size="'medium'" :color="'blue'"></custom-button>
-
-        <custom-button class="ml-auto text-sm mt-4"  v-if="this.user.patreon_account" :ignoreclick="true" :text="'Remove Patreon'" :alt="'Remove Patreon'"  :size="'medium'" :color="'red'" @click="removePatreon()"></custom-button>
-      </div>
-
-
     </div>
+  </div>
+  <div class="mx-auto w-full max-w-[1200px] mt-4 px-2 text-sm text-gray-400">
+    To request new settings, please contact us directly at
+    <a href="mailto:Zemill@heroesprofile.com" class="link">Zemill@heroesprofile.com</a>,
+    or open a discussion on
+    <a href="https://github.com/Heroes-Profile/heroesprofile/discussions" target="_blank" class="link">GitHub</a>.
+  </div>
+  </div>
 
-    
-  </div>
-  <div v-else>
-    <loading-component></loading-component>
-  </div>
 </template>
 
 <script>
 export default {
-  name: 'Profile',
-  components: {
-  },
+  name: 'ProfileSettings',
   props: {
     user: Object,
     filters: Object,
   },
-  data(){
+  data() {
     return {
       isLoading: false,
+      activeTab: 'general',
+      tabs: [
+        { key: 'general',     label: 'General' },
+        { key: 'global',      label: 'Global Pages' },
+        { key: 'player',      label: 'Player' },
+        { key: 'connections', label: 'Connections' },
+      ],
+
       userhero: null,
       usergametype: null,
       mmrplayerusergametype: null,
       usermultigametype: null,
-      advancedfilteringoptions: [
-        { code: 'true', name: 'Show' },
-        { code: 'false', name: "Don't Show" }
-      ],
-      privateOptions: [
-        { code: 'true', name: 'Private' },
-        { code: 'false', name: "Not Private" }
-      ],
-      playerdataloadstyles: [
-        { code: 'true', name: 'Standard' },
-        { code: 'false', name: "No load" }
-      ],
-      showcustomgames: [
-        { code: false, name: "Don't Show" },
-        { code: true, name: 'Show' }
-
-      ],
+      savemultigametype: null,
       advancedfiltering: null,
-      accountVisibility: 'false',
       talentBuildType: null,
-      settingsSaved: false,
-      darkmode: false,
-      playerhistorytable: true,
-      overridedefaultside: null,
-
-
-      defaultMultiGameTypeOverride: null,
+      darkmode: 'left',
+      playerhistorytable: 'left',
       playerload: 'true',
       customgames: false,
-      savemultigametype: null,
-    }
-  },
-  created(){
-    if(this.user.private == 1){
-      this.accountVisibility = "true";
-    }else{
-      this.accountVisibility = "false";
-    }
+      accountVisibility: 'false',
+      settingsSaved: false,
 
+      advancedfilteringoptions: [
+        { code: 'true',  name: 'Show' },
+        { code: 'false', name: "Don't Show" },
+      ],
+      privateOptions: [
+        { code: 'true',  name: 'Private' },
+        { code: 'false', name: 'Not Private' },
+      ],
+      playerdataloadstyles: [
+        { code: 'true',  name: 'Standard' },
+        { code: 'false', name: 'No Load' },
+      ],
+      showcustomgamesoptions: [
+        { code: false, name: "Don't Show" },
+        { code: true,  name: 'Show' },
+      ],
+    };
+  },
+  created() {
+    this.accountVisibility = this.user.private == 1 ? 'true' : 'false';
     this.usergametype = this.defaultGameType;
     this.mmrplayerusergametype = this.defaultMMRPlayerGameType;
     this.usermultigametype = this.defaultMultiGameType;
@@ -236,107 +252,84 @@ export default {
     this.darkmode = this.defaultDarkMode;
     this.playerhistorytable = this.defaultPlayerhistorytable;
     this.customgames = this.defaultCustomGames;
-  },
-  mounted() {
+    this.playerload = this.defaultPlayerLoad;
   },
   computed: {
-    defaultHero(){
-      if (this.user.user_settings.length > 0){
-        let hero = this.user.user_settings.find(item => item.setting === 'hero');
-        return hero ? hero.value : null;
-      }
-      return null;
-    },
     defaultMultiGameType() {
       if (this.user.user_settings.length > 0) {
-        let multiGameTypes = this.user.user_settings.find(item => item.setting === 'multi_game_type');
-        let gameTypes = multiGameTypes ? multiGameTypes.value : null;
-
-        if (gameTypes && gameTypes.trim() !== '') {
-          return gameTypes.split(',').map(value => value.trim());
+        let setting = this.user.user_settings.find(item => item.setting === 'multi_game_type');
+        if (setting && setting.value.trim() !== '') {
+          return setting.value.split(',').map(v => v.trim());
         }
       }
-      return ["sl"];
+      return ['sl'];
     },
     defaultGameType() {
       if (this.user.user_settings.length > 0) {
-        let gameTypeSetting = this.user.user_settings.find(item => item.setting === 'game_type');
-        return gameTypeSetting ? gameTypeSetting.value : null;
+        let setting = this.user.user_settings.find(item => item.setting === 'game_type');
+        return setting ? setting.value : 'sl';
       }
-      return "sl";
+      return 'sl';
     },
     defaultMMRPlayerGameType() {
       if (this.user.user_settings.length > 0) {
-        let gameTypeSetting = this.user.user_settings.find(item => item.setting === 'mmr_player_game_type');
-        return gameTypeSetting ? gameTypeSetting.value : "sl";
+        let setting = this.user.user_settings.find(item => item.setting === 'mmr_player_game_type');
+        return setting ? setting.value : 'sl';
       }
-      return "sl";
+      return 'sl';
     },
-    defaultBuildType(){
-      if (this.user.user_settings.length > 0){
-        let buildtype = this.user.user_settings.find(item => item.setting === 'talentbuildtype');
-        return buildtype ? buildtype.value : null;
+    defaultBuildType() {
+      if (this.user.user_settings.length > 0) {
+        let setting = this.user.user_settings.find(item => item.setting === 'talentbuildtype');
+        return setting ? setting.value : this.filters.talent_build_types[0].code;
       }
       return this.filters.talent_build_types[0].code;
     },
-    defaultAdvancedFiltering(){
-      if (this.user.user_settings.length > 0){
-        let advancedfiltering = this.user.user_settings.find(item => item.setting === 'advancedfiltering');
-        return advancedfiltering ? advancedfiltering.value : 'false';
+    defaultAdvancedFiltering() {
+      if (this.user.user_settings.length > 0) {
+        let setting = this.user.user_settings.find(item => item.setting === 'advancedfiltering');
+        return setting ? setting.value : 'false';
       }
-      return "false";
+      return 'false';
     },
-    defaultDarkMode(){
-      if (this.user.user_settings.length > 0){
-        let darkmode = this.user.user_settings.find(item => item.setting === 'darkmode');
-        if(darkmode && darkmode.value == 1){
-          return "right";
-        }else{
-          return "left";
-        }
+    defaultDarkMode() {
+      if (this.user.user_settings.length > 0) {
+        let setting = this.user.user_settings.find(item => item.setting === 'darkmode');
+        return (setting && setting.value == 1) ? 'right' : 'left';
       }
-      return "left";
+      return 'left';
     },
-    defaultPlayerhistorytable(){
-      if (this.user.user_settings.length > 0){
-        let playerhistorytable = this.user.user_settings.find(item => item.setting === 'playerhistorytable');
-        if(playerhistorytable && playerhistorytable.value == 1){
-          return "right";
-        }else{
-          return "left";
-        }
+    defaultPlayerhistorytable() {
+      if (this.user.user_settings.length > 0) {
+        let setting = this.user.user_settings.find(item => item.setting === 'playerhistorytable');
+        return (setting && setting.value == 1) ? 'right' : 'left';
       }
-      return "left";
+      return 'left';
     },
-    defaultCustomGames(){
-      if (this.user.user_settings.length > 0){
-        let customgames = this.user.user_settings.find(item => item.setting === 'customgames');
-        return customgames ? customgames.value == 1 ? true : false : false;
+    defaultCustomGames() {
+      if (this.user.user_settings.length > 0) {
+        let setting = this.user.user_settings.find(item => item.setting === 'customgames');
+        return setting ? (setting.value == 1 ? true : false) : false;
       }
       return false;
     },
-  },
-  watch: {
+    defaultPlayerLoad() {
+      if (this.user.user_settings.length > 0) {
+        let setting = this.user.user_settings.find(item => item.setting === 'playerload');
+        return setting ? setting.value : 'true';
+      }
+      return 'true';
+    },
   },
   methods: {
-    async saveSettings(){
+    async saveSettings() {
       this.isLoading = true;
 
-      let darkmodeinput = this.darkmode;
-      if(darkmodeinput == "right"){
-        darkmodeinput = true;
-      }else if(darkmodeinput == "left"){
-        darkmodeinput = false;
-      }
+      let darkmodeinput = this.darkmode === 'right' ? true : false;
+      let playerhistorytableinput = this.playerhistorytable === 'right' ? true : false;
 
-      let playerhistorytableinput = this.playerhistorytable;
-      if(playerhistorytableinput == "right"){
-        playerhistorytableinput = true;
-      }else if(playerhistorytableinput == "left"){
-        playerhistorytableinput = false;
-      }
-      try{
-        const response = await this.$axios.post("/api/v1/profile/save/settings", {
+      try {
+        await this.$axios.post('/api/v1/profile/save/settings', {
           userid: this.user.battlenet_accounts_id,
           userhero: this.userhero,
           usergametype: this.usergametype,
@@ -349,82 +342,73 @@ export default {
           customgames: this.customgames,
           playerhistorytable: playerhistorytableinput,
         });
-        //window.location.href = "/Profile/Settings";
         this.settingsSaved = true;
-        setTimeout(() => {
-          this.settingsSaved = false;
-        }, 5000);
+        setTimeout(() => { this.settingsSaved = false; }, 5000);
         this.usermultigametype = this.savemultigametype;
-        
-      }catch(error){
-        //Do something here
+      } catch (error) {
+        // handle error
       }
       this.isLoading = false;
     },
-    async setAccountVisbility(){
-      try{
-        const response = await this.$axios.post("/api/v1/profile/set/account/visibility", {
+    async setAccountVisbility() {
+      try {
+        await this.$axios.post('/api/v1/profile/set/account/visibility', {
           userid: this.user.battlenet_accounts_id,
           accountVisibility: this.accountVisibility,
         });
-      }catch(error){
-        //Do something here
+      } catch (error) {
+        // handle error
+      }
+    },
+    async removePatreon() {
+      try {
+        await this.$axios.post('/api/v1/profile/remove/patreon', {
+          userid: this.user.battlenet_accounts_id,
+        });
+        window.location.href = '/Profile/Settings';
+      } catch (error) {
+        // handle error
       }
     },
     handleInputChange(eventPayload) {
-      if(eventPayload.type === 'single') {
-        if(eventPayload.field == "Heroes"){
-          this.userhero = this.filters.heroes.find(hero => hero.code === eventPayload.value).name;
-        }else if(eventPayload.field == "Advanced Filtering"){
-          this.advancedfiltering = eventPayload.value;
-        }else if(eventPayload.field == "Account Visibility"){
-          this.accountVisibility = eventPayload.value;
-        }else if(eventPayload.field == "Talent Build Type"){
-          this.talentBuildType = eventPayload.value;
-        }else if(eventPayload.field == "Game Type"){
-          this.usergametype = eventPayload.value;
-        }else if(eventPayload.field == "HP MMR Game Type" || eventPayload.field == "MMR Game Type"){
-          this.mmrplayerusergametype = eventPayload.value;
-        }else if(eventPayload.field == "Player Load"){
-          this.playerload = eventPayload.value;
-        }else if(eventPayload.field == "Show Custom Games"){
-          this.customgames = eventPayload.value;
+      if (eventPayload.type === 'single') {
+        const { field, value } = eventPayload;
+        if (field === 'Heroes') {
+          this.userhero = this.filters.heroes.find(h => h.code === value)?.name;
+        } else if (field === 'Advanced Filtering') {
+          this.advancedfiltering = value;
+        } else if (field === 'Account Visibility') {
+          this.accountVisibility = value;
+        } else if (field === 'Talent Build Type') {
+          this.talentBuildType = value;
+        } else if (field === 'Game Type') {
+          this.usergametype = value;
+        } else if (field === 'HP MMR Game Type' || field === 'MMR Game Type') {
+          this.mmrplayerusergametype = value;
+        } else if (field === 'Player Load') {
+          this.playerload = value;
+        } else if (field === 'Show Custom Games') {
+          this.customgames = value;
         }
-
-      } else if(eventPayload.type === 'multi') {
-        if(eventPayload.field == "Game Type"){
+      } else if (eventPayload.type === 'multi') {
+        if (eventPayload.field === 'Game Type') {
           this.savemultigametype = eventPayload.value;
         }
       }
-   
     },
-    darkmodesetting(side){
-      if(side == "right"){
-        this.darkmode = true;
-      }else{
-        this.darkmode = false;
-      }
+    darkmodesetting(side) {
+      this.darkmode = side;
       this.saveSettings();
     },
-    playermatchhistorystylesetting(side){
-      if(side == "right"){
-        this.playerhistorytable = true;
-      }else{
-        this.playerhistorytable = false;
-      }
+    playermatchhistorystylesetting(side) {
+      this.playerhistorytable = side;
       this.saveSettings();
     },
-
-    async removePatreon(){
-      try{
-        const response = await this.$axios.post("/api/v1/profile/remove/patreon", {
-          userid: this.user.battlenet_accounts_id,
-        });
-        window.location.href = "/Profile/Settings";
-      }catch(error){
-        //Do something here
-      }
-    },
-  }
-}
+  },
+};
 </script>
+
+<style scoped>
+.fade-enter-active, .fade-leave-active { transition: opacity 0.4s; }
+.fade-enter, .fade-leave-to { opacity: 0; }
+</style>


### PR DESCRIPTION
## Summary
- Replaces the flat single-column settings page with a tabbed sidebar layout (General, Global Pages, Player, Connections)
- Adds `<page-heading>` banner matching the rest of the site
- Loading overlay uses the spinning Heroes Profile logo with \"Saving...\" text and blocks interaction during saves
- Fixes a bug where `v-if=\"!isLoading\"` on the root element caused the entire component to unmount/remount on every setting save
- Adds a footer with contact info for requesting new settings
- Moves Account Visibility to the General tab
- Moves Patreon linking to the Connections tab

## Test plan
- [x] Navigate to /Profile/Settings and verify the new tabbed layout renders
- [x] Switch between all four tabs (General, Global Pages, Player, Connections) and verify no resize/jump
- [x] Change a setting and verify the spinning logo overlay appears then disappears, and \"Settings Saved\" banner shows
- [x] Verify all settings load correctly from saved user preferences on page load
- [x] Verify Patreon connect/disconnect works from Connections tab
- [x] Verify Account Visibility saves correctly from General tab