### PR TITLE
Player profile filter improvements, FAQ patch history, and bug fixes

### DIFF
--- a/app/Http/Controllers/FaqController.php
+++ b/app/Http/Controllers/FaqController.php
@@ -3,14 +3,37 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class FaqController extends Controller
 {
     public function show(Request $request)
     {
+        $versions = DB::table('season_game_versions')
+            ->where('valid_globals', 1)
+            ->orderBy('date_added')
+            ->orderBy('id')
+            ->get(['id', 'season', 'game_version', 'date_added', 'patch_notes_url'])
+            ->values();
+
+        $patchHistory = [];
+        foreach ($versions as $i => $v) {
+            $next = $versions[$i + 1] ?? null;
+            $patchHistory[] = [
+                'season' => $v->season,
+                'game_version' => $v->game_version,
+                'patch_notes_url' => $v->patch_notes_url ?: null,
+                'start_date' => substr($v->date_added, 0, 10),
+                'end_date' => $next ? substr($next->date_added, 0, 10) : null,
+            ];
+        }
+
+        $patchHistory = array_reverse($patchHistory);
+
         return view('faq')->with([
             'bladeGlobals' => $this->globalDataService->getBladeGlobals(),
             'recaptchaSiteKey' => config('services.recaptcha.site_key'),
+            'patchHistory' => $patchHistory,
         ]);
     }
 }

--- a/app/Http/Controllers/Player/PlayerMMRController.php
+++ b/app/Http/Controllers/Player/PlayerMMRController.php
@@ -7,10 +7,13 @@ use App\Models\GameType;
 use App\Models\Hero;
 use App\Models\LeagueBreakdown;
 use App\Models\MMRTypeID;
+use App\Models\SeasonDate;
 use App\Rules\GameTypeInputValidation;
 use App\Rules\HeroInputByIDValidation;
 use App\Rules\RoleInputValidation;
+use App\Rules\SeasonInputValidation;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 
@@ -62,6 +65,7 @@ class PlayerMMRController extends Controller
             'type' => 'required|in:Player,Hero,Role',
             'hero' => ['required_if:type,Hero', 'nullable', new HeroInputByIDValidation],
             'role' => ['required_if:type,Role', 'nullable', new RoleInputValidation],
+            'season' => ['sometimes', 'nullable', new SeasonInputValidation],
         ];
 
         $validator = Validator::make($request->all(), $validationRules);
@@ -80,6 +84,7 @@ class PlayerMMRController extends Controller
         $hero = $request['hero'] ? $this->globalDataService->getHeroesByID()[$request['hero']] : null;
         $type = $request['type'];
         $role = $request['role'];
+        $season = $request['season'];
 
         if ($type == 'Hero' && $hero == null) {
             return [
@@ -122,6 +127,15 @@ class PlayerMMRController extends Controller
             })
             ->when(! is_null($role), function ($query) use ($role) {
                 return $query->whereIn('hero', Hero::select('id')->where('new_role', $role)->get()->toArray());
+            })
+            ->when(! is_null($season), function ($query) use ($season) {
+                $seasonDate = Cache::remember('season_date_'.$season, 3600, fn () => SeasonDate::find($season));
+                if ($seasonDate) {
+                    return $query->where('game_date', '>=', $seasonDate->start_date)
+                        ->where('game_date', '<', $seasonDate->end_date);
+                }
+
+                return $query;
             })
             // ->toSql();
             ->orderByDesc('mmr_date_parsed')

--- a/app/Http/Controllers/Player/PlayerMapsController.php
+++ b/app/Http/Controllers/Player/PlayerMapsController.php
@@ -93,7 +93,6 @@ class PlayerMapsController extends Controller
             'map' => $map,
             'mapobject' => $mapobject,
             'filters' => $this->globalDataService->getFilterData(),
-            'bladeGlobals' => $this->globalDataService->getBladeGlobals(),
             'patreon' => $this->globalDataService->checkIfSiteFlair($blizz_id, $region),
             'gametypedefault' => null, // $this->globalDataService->getGameTypeDefault('single'), //Removing user defined setting.  Doesnt make sense to me not to show ALL data for player profile pages to start
 

--- a/app/Http/Controllers/Player/PlayerMatchHistory.php
+++ b/app/Http/Controllers/Player/PlayerMatchHistory.php
@@ -112,6 +112,7 @@ class PlayerMatchHistory extends Controller
             'hero' => ['sometimes', 'nullable', new HeroInputByIDValidation],
             'game_map' => ['sometimes', 'nullable', new GameMapInputValidation],
             'season' => ['sometimes', 'nullable', new SeasonInputValidation],
+            'stack_size' => ['sometimes', 'nullable', 'string', 'in:All,Solo,Duo,3 Players,4 Players,5 Players'],
             'pagination_page' => 'required:integer',
         ];
 
@@ -134,6 +135,14 @@ class PlayerMatchHistory extends Controller
         $hero = $request['hero'];
         $game_map = $request['game_map'] ? Map::whereIn('name', $request['game_map'])->pluck('map_id')->toArray() : null;
         $season = $request['season'];
+        $stack_size = match ($request['stack_size'] ?? null) {
+            'Solo' => 1,
+            'Duo' => 2,
+            '3 Players' => 3,
+            '4 Players' => 4,
+            '5 Players' => 5,
+            default => null,
+        };
 
         $pagination_page = $request['pagination_page'];
         $perPage = 100;
@@ -193,6 +202,9 @@ class PlayerMatchHistory extends Controller
             })
             ->when(! is_null($hero), function ($query) use ($hero) {
                 return $query->where('hero', $hero);
+            })
+            ->when(! is_null($stack_size), function ($query) use ($stack_size) {
+                return $query->where('stack_size', $stack_size);
             })
             ->orderByDesc('game_date')
             ->paginate($perPage, ['*'], 'page', $pagination_page);

--- a/resources/js/components/Faq.vue
+++ b/resources/js/components/Faq.vue
@@ -44,6 +44,34 @@
         </div>
       </div>
 
+      <!-- Patch & Season History -->
+      <div id="patch-history" class="mt-10 mb-8">
+        <h2 class="bg-teal px-4 py-3 rounded-t-lg text-lg font-semibold">Patch &amp; Season History</h2>
+        <div class="bg-lighten rounded-b-lg p-4">
+          <table class="patch-history-table" style="border-collapse:collapse; font-size:0.875rem; width:100%;">
+            <thead>
+              <tr>
+                <th style="padding:4px 8px; text-align:left;">Season</th>
+                <th style="padding:4px 8px; text-align:left;">Game Version</th>
+                <th style="padding:4px 8px; text-align:left; white-space:nowrap;">Start Date</th>
+                <th style="padding:4px 8px; text-align:left; white-space:nowrap;">End Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(row, i) in patchHistory" :key="i">
+                <td style="padding:3px 8px;">{{ row.season }}</td>
+                <td style="padding:3px 8px;">
+                  <a v-if="row.patch_notes_url" :href="row.patch_notes_url" target="_blank" class="link">{{ row.game_version }}</a>
+                  <span v-else>{{ row.game_version }}</span>
+                </td>
+                <td style="padding:3px 8px;">{{ formatDate(row.start_date) }}</td>
+                <td style="padding:3px 8px;">{{ row.end_date ? formatDate(row.end_date) : 'Present' }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
       <!-- Ask a Question -->
       <div class="mt-12 mb-8">
         <h2 class="bg-teal px-4 py-3 rounded-t-lg text-lg font-semibold">Still have a question?</h2>
@@ -113,7 +141,11 @@ export default {
     recaptchaSiteKey: {
       type: String,
       default: ''
-    }
+    },
+    patchHistory: {
+      type: Array,
+      default: () => []
+    },
   },
   data() {
     return {
@@ -343,6 +375,9 @@ export default {
     },
   },
   methods: {
+    formatDate(dateStr) {
+      return new Date(dateStr).toLocaleDateString(undefined, { year: 'numeric', month: '2-digit', day: '2-digit' });
+    },
     toggle(catName, index) {
       const key = `${catName}-${index}`;
       this.openItems = { ...this.openItems, [key]: !this.openItems[key] };
@@ -402,3 +437,9 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.patch-history-table {
+  min-width: 0 !important;
+}
+</style>

--- a/resources/js/components/Filtering/Filters.vue
+++ b/resources/js/components/Filtering/Filters.vue
@@ -74,11 +74,12 @@
           ></single-select-filter>
 
           <!-- Timeframes -->
-          <multi-select-filter v-if="includetimeframemodified" 
-            :values="timeframes" 
-            :text="'Timeframes'" 
-            :defaultValue="timeframe" 
+          <multi-select-filter v-if="includetimeframemodified"
+            :values="timeframes"
+            :text="'Timeframes'"
+            :defaultValue="timeframe"
             @input-changed="handleInputChange"
+            infolink="/FAQ#patch-history"
           ></multi-select-filter>
 
           <!-- Current Game Type Multiselect-->

--- a/resources/js/components/Filtering/MultiSelectFilter.vue
+++ b/resources/js/components/Filtering/MultiSelectFilter.vue
@@ -3,6 +3,11 @@
     <div @click="showOptions = !showOptions" class="flex flex-col text-sm font-medium text-gray-700 cursor-pointer  p-2    transition-colors">
       <span class="relative">
         <span class="relative">{{ this.text }}
+          <round-image v-if="infolink" class="mt-2" size="small" icon="fas fa-info" title="info" popupsize="large" mobileClick="true" :hidedelay="1000" style="position:absolute; bottom:0; right:-25px;">
+            <div>
+              <p class="max-sm:text-xs">Timeframes correspond to game patches. <a :href="infolink" target="_blank" class="link">View the full patch & season history.</a></p>
+            </div>
+          </round-image>
           <round-image v-if="showrankinfo" class="mt-2"  size="small"    icon="fas fa-info"   title="info"  popupsize="large" mobileClick="true" style="position:absolute; bottom:0; right:-25px;">
             <slot>
               <div>
@@ -62,6 +67,7 @@
       defaultValue: Array,
       trackclosure: Boolean,
       showrankinfo: Boolean,
+      infolink: String,
     },
     data(){
       return {

--- a/resources/js/components/Player/Heroes/PlayerHeroesAllStats.vue
+++ b/resources/js/components/Player/Heroes/PlayerHeroesAllStats.vue
@@ -13,6 +13,7 @@
       :hideadvancedfilteringbutton="true"
       :includegamemap="true"
       :includeseasonwithall="true"
+      :includehero="true"
       >
     </filters>
     <dynamic-banner-ad :patreon-user="patreonUser"></dynamic-banner-ad>

--- a/resources/js/components/Player/MmrData.vue
+++ b/resources/js/components/Player/MmrData.vue
@@ -11,6 +11,7 @@
       :hideadvancedfilteringbutton="true"
       :rolerequired="true"
       :herorequired="true"
+      :includeseasonwithall="true"
       >
     </filters>
     
@@ -154,6 +155,7 @@ export default {
       userTimezone: moment.tz.guess(),
       isLoading: false,
       gametype: null,
+      season: null,
       data: null,
       sortKey: '',
       sortDir: 'desc',
@@ -218,6 +220,7 @@ export default {
           type: this.type,
           hero: this.hero,
           role: this.role,
+          season: this.season,
         }, 
         {
           cancelToken: this.cancelTokenSource.token,
@@ -252,6 +255,8 @@ export default {
       this.hero = filteredData.single.Heroes ? filteredData.single.Heroes : null;
       this.minimumgames = filteredData.single["Minimum Games"] ? filteredData.single["Minimum Games"] : 0;
       this.type = filteredData.single["Type"] ? filteredData.single["Type"] : "Player";
+      this.season = filteredData.single.Season ? filteredData.single.Season : null;
+      if (this.season == "All") this.season = null;
 
       this.data = null;
       this.sortKey = '';

--- a/resources/js/components/Player/PlayerMatchHistory.vue
+++ b/resources/js/components/Player/PlayerMatchHistory.vue
@@ -16,6 +16,8 @@
       :includegametypefullcustom="showcustomgames"
       :includeseason="true"
       :includegamemap="true"
+      :includegroupsize="true"
+      :groupSizeDefaultValue="'All'"
       :hideadvancedfilteringbutton="true"
       >
     </filters>
@@ -165,6 +167,7 @@ export default {
       hero: null,
       gamemap: null,
       season: null,
+      stack_size: null,
       sortKey: '',
       sortDir: 'desc',
       gametype: null,
@@ -233,6 +236,7 @@ export default {
           game_map: this.gamemap,
           pagination_page: page,
           season: this.season,
+          stack_size: this.stack_size,
         }, 
         {
           cancelToken: this.cancelTokenSource.token,
@@ -272,6 +276,7 @@ export default {
       this.hero = filteredData.single.Heroes ? filteredData.single.Heroes : null;
       this.hero = this.hero ? this.filters.heroes.find(h => h.code === this.hero)?.name : null;
       this.season = filteredData.single.Season ? filteredData.single.Season : null;
+      this.stack_size = filteredData.single["Group Size"] ? filteredData.single["Group Size"] : null;
       this.gametype = filteredData.multi["Game Type"] ? Array.from(filteredData.multi["Game Type"]) : this.gametype;
       this.gamemap = filteredData.multi.Map ? Array.from(filteredData.multi.Map) : null;
 

--- a/resources/js/components/Player/Roles/PlayerRolesAllStats.vue
+++ b/resources/js/components/Player/Roles/PlayerRolesAllStats.vue
@@ -13,6 +13,7 @@
     :hideadvancedfilteringbutton="true"
     :includegamemap="true"
     :includeseasonwithall="true"
+    :includehero="true"
     >
   </filters>
   <dynamic-banner-ad :patreon-user="patreonUser"></dynamic-banner-ad>

--- a/resources/js/components/RoundImage.vue
+++ b/resources/js/components/RoundImage.vue
@@ -21,7 +21,7 @@
     }
   ]"
   
-  @mouseover="handleMouseOver" @mouseleave="showTooltip = false">
+  @mouseover="handleMouseOver" @mouseleave="scheduleHide">
 
     <div class="absolute z-10 bottom-0 right-0 w-9"  v-if="award">
       <img :src="awardicon"/>
@@ -63,8 +63,8 @@
       :src="image" 
       :alt="title">
     
-    <div v-show="showTooltip" :class="[
-        'absolute hidden group-hover:block text-xs z-40',
+    <div v-show="showTooltip" @mouseover="handleMouseOver" @mouseleave="scheduleHide" :class="[
+        'absolute text-xs z-40',
       {
         // Default top positioning
         'left-1/2 transform -translate-x-1/2 bottom-[1em] -translate-y-[2em]': tooltipPosition === 'top',
@@ -120,13 +120,18 @@ export default {
     hpowner: Boolean,
     ispatreon: Boolean,
     icon: String,
-    mobileClick: false
+    mobileClick: false,
+    hidedelay: {
+      type: Number,
+      default: 0,
+    }
     
   },
   data(){
     return {
       showTooltip: false,
-      tooltipPosition: 'top', // 'top', 'right', or 'left'
+      tooltipPosition: 'top',
+      hideTimer: null,
     }
   },
   created(){
@@ -141,7 +146,15 @@ export default {
     isSmallScreen() {
       return window.innerWidth <= 768; // You can adjust the threshold as needed
     },
+    scheduleHide() {
+      if (this.hidedelay === 0) {
+        this.showTooltip = false;
+      } else {
+        this.hideTimer = setTimeout(() => { this.showTooltip = false; }, this.hidedelay);
+      }
+    },
     handleMouseOver() {
+      clearTimeout(this.hideTimer);
       this.showTooltip = true;
       this.calculateTooltipPosition();
     },

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -7,7 +7,9 @@
             /* 4 => 'UNK', */
             5 => 'CN',
         ],
-        'darkmode' => 0, // Set your default dark mode value here
+        'darkmode' => 0,
+        'heroes' => [],
+        'maps' => [],
     ];
 @endphp
 

--- a/resources/views/errors/429.blade.php
+++ b/resources/views/errors/429.blade.php
@@ -8,6 +8,8 @@
             5 => 'CN',
         ],
         'darkmode' => 0,
+        'heroes' => [],
+        'maps' => [],
     ];
 @endphp
 

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -7,7 +7,9 @@
             /* 4 => 'UNK', */
             5 => 'CN',
         ],
-        'darkmode' => 0, // Set your default dark mode value here
+        'darkmode' => 0,
+        'heroes' => [],
+        'maps' => [],
     ];
 @endphp
 

--- a/resources/views/faq.blade.php
+++ b/resources/views/faq.blade.php
@@ -3,5 +3,5 @@
 @section('meta_keywords', 'Heroes Profile FAQ, frequently asked questions, Heroes of the Storm stats')
 @section('meta_description', 'Frequently asked questions about Heroes Profile — uploading replays, MMR, global stats, site features, and more.')
 @section('content')
-  <faq :recaptcha-site-key="'{{ $recaptchaSiteKey }}'"></faq>
+  <faq :recaptcha-site-key="'{{ $recaptchaSiteKey }}'" :patch-history="{{ json_encode($patchHistory) }}"></faq>
 @endsection


### PR DESCRIPTION
## Summary

- **Player profile filters**: Added missing Hero filter to Hero Stats and Roles pages; added Season filter to MMR page; added Group Size filter to Match History page (defaults to All)
- **FAQ patch & season history**: New table on the FAQ page showing season, game version, and date ranges for every patch, with locale-aware date formatting; linked from the Timeframes filter via an info icon popup
- **Error page fix**: 404, 429, and 500 error pages were missing `heroes` and `maps` keys in their hardcoded `bladeGlobals`, causing a secondary crash when the nav tried to render them — now fixed at the source
- **RoundImage tooltip fix**: Tooltip was hiding instantly via CSS `group-hover` before the JS delay could fire; switched to `v-show`-only control and added a `hidedelay` prop so popups with clickable links stay open long enough to interact with
- **PlayerMapsController**: Removed duplicate `getBladeGlobals()` call