### PR TITLE
Adds all-hero talent builds table to Global Talents page

### DIFF
--- a/app/Http/Controllers/Global/GlobalTalentStatsController.php
+++ b/app/Http/Controllers/Global/GlobalTalentStatsController.php
@@ -12,6 +12,7 @@ use App\Rules\HeroInputValidation;
 use App\Rules\StatFilterInputValidation;
 use App\Rules\TalentBuildTypeInputValidation;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Validator;
 
 class GlobalTalentStatsController extends GlobalsInputValidationController
@@ -277,6 +278,69 @@ class GlobalTalentStatsController extends GlobalsInputValidationController
         $cacheKey = 'GlobalHeroTalentStatsBuilds|'.implode(',', SeasonGameVersion::select('id')->whereIn('game_version', $gameVersion)->pluck('id')->toArray()).'|'.hash('sha256', json_encode($request->all()));
 
         return $this->asyncGlobalResponse($request, $cacheKey, $gameVersion, 'executeGlobalHeroTalentBuildData');
+    }
+
+    public function getGlobalHeroTalentBuildDataAll(Request $request)
+    {
+        $heroes = $this->globalDataService->getHeroes();
+        $cache = Cache::store('database');
+        $talentbuildType = $request['talentbuildtype'] ?? $this->globalDataService->getDefaultBuildType();
+        $timeframeType = $request['timeframe_type'] ?? $this->globalDataService->getDefaultTimeframeType();
+        $timeframe = $request['timeframe'] ?? [$this->globalDataService->getDefaultTimeframe()];
+
+        $allCacheKey = 'GlobalHeroTalentStatsBuildsAll|'.hash('sha256', json_encode([
+            'timeframe_type' => $timeframeType,
+            'timeframe' => $timeframe,
+            'talentbuildtype' => $talentbuildType,
+        ]));
+
+        $cachedAll = $cache->get($allCacheKey);
+        if ($cachedAll !== null) {
+            return $cachedAll;
+        }
+
+        $gameTypes = ['qm', 'sl', 'ar'];
+        $gameVersion = $timeframeType === 'last_update'
+            ? null
+            : $this->globalDataService->getTimeframeFilterValues($timeframeType, $timeframe);
+
+        $result = [];
+
+        foreach ($heroes as $heroModel) {
+            $result[$heroModel->name] = [];
+
+            foreach ($gameTypes as $gameType) {
+                $heroRequest = Request::create('/api/v1/global/talents/build', 'POST', array_merge([
+                    'hero' => $heroModel->name,
+                ], $request->all(), [
+                    'talentbuildtype' => $talentbuildType,
+                    'timeframe_type' => $timeframeType,
+                    'timeframe' => $timeframe,
+                    'game_type' => [$gameType],
+                ]));
+
+                $resolvedGameVersion = $timeframeType === 'last_update'
+                    ? $this->globalDataService->getTimeframeFilterValuesLastUpdate($heroModel->id)
+                    : $gameVersion;
+
+                $cacheKey = 'GlobalHeroTalentStatsBuilds|'.implode(',', SeasonGameVersion::select('id')->whereIn('game_version', $resolvedGameVersion)->pluck('id')->toArray()).'|'.hash('sha256', json_encode($heroRequest->all()));
+
+                $cached = $cache->get($cacheKey);
+
+                if ($cached !== null) {
+                    $result[$heroModel->name][$gameType] = $cached;
+                } else {
+                    $result[$heroModel->name][$gameType] = $this->executeGlobalHeroTalentBuildData($heroRequest);
+                }
+            }
+        }
+
+        $cacheTtlSeconds = $this->globalDataService->calculateCacheTimeInSeconds(
+            $gameVersion ?? $this->globalDataService->getTimeframeFilterValues($timeframeType, $timeframe)
+        );
+        $cache->put($allCacheKey, $result, $cacheTtlSeconds);
+
+        return $result;
     }
 
     public function executeGlobalHeroTalentBuildData(Request $request)

--- a/resources/js/components/Global/Talents/GlobalTalentBuildsAll.vue
+++ b/resources/js/components/Global/Talents/GlobalTalentBuildsAll.vue
@@ -1,0 +1,103 @@
+<template>
+  <div class="w-full">
+    <table class="w-full text-sm">
+      <thead>
+        <tr>
+          <th class="py-2 px-3 text-left text-sm leading-4 text-gray-500 tracking-wider">Hero</th>
+          <th class="py-2 px-3 text-left text-sm leading-4 text-gray-500 tracking-wider">Quick Match</th>
+          <th class="py-2 px-3 text-left text-sm leading-4 text-gray-500 tracking-wider">Storm League</th>
+          <th class="py-2 px-3 text-left text-sm leading-4 text-gray-500 tracking-wider">ARAM</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="hero in heroes" :key="hero.id" class="border-t border-gray-700">
+          <td class="py-2 px-3 whitespace-nowrap">
+            <div class="flex items-center">
+              <hero-image-wrapper class="mr-2" :hero="hero" :includehover="false"></hero-image-wrapper>
+              <span class="hidden md:block">{{ hero.name }}</span>
+            </div>
+          </td>
+          <td v-for="gt in ['qm', 'sl', 'ar']" :key="gt" class="py-2 px-3">
+            <template v-if="firstBuild(hero.name, gt)">
+              <div class="flex flex-wrap gap-4">
+                <talent-image-wrapper :talent="firstBuild(hero.name, gt).level_one"></talent-image-wrapper>
+                <talent-image-wrapper :talent="firstBuild(hero.name, gt).level_four"></talent-image-wrapper>
+                <talent-image-wrapper :talent="firstBuild(hero.name, gt).level_seven"></talent-image-wrapper>
+                <talent-image-wrapper :talent="firstBuild(hero.name, gt).level_ten"></talent-image-wrapper>
+                <talent-image-wrapper :talent="firstBuild(hero.name, gt).level_thirteen"></talent-image-wrapper>
+                <talent-image-wrapper :talent="firstBuild(hero.name, gt).level_sixteen"></talent-image-wrapper>
+                <talent-image-wrapper :talent="firstBuild(hero.name, gt).level_twenty"></talent-image-wrapper>
+              </div>
+              <div class="flex items-center gap-2 mt-1">
+                <span class="text-xs text-gray-400">{{ getCopyBuildToGame(firstBuild(hero.name, gt)) }}</span>
+                <i
+                  :class="['fa-solid fa-copy cursor-pointer', copyColor(hero.name, gt) === 'teal' ? 'text-teal-400' : 'text-gray-400', 'hover:text-white']"
+                  :title="copyLabel(hero.name, gt)"
+                  @click="copyToClipboard(hero.name, gt)"
+                ></i>
+              </div>
+            </template>
+            <span v-else class="text-gray-500">—</span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'GlobalTalentBuildsAll',
+  props: {
+    heroes: {
+      type: Array,
+      required: true,
+    },
+    talentbuilddataall: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      copiedState: {},
+    };
+  },
+  methods: {
+    firstBuild(heroName, gameType) {
+      const builds = this.talentbuilddataall?.[heroName]?.[gameType];
+      return builds && builds.length > 0 ? builds[0] : null;
+    },
+    getCopyBuildToGame(build) {
+      const b = build;
+      return "[T" +
+        (b.level_one     ? b.level_one.sort     : '0') +
+        (b.level_four    ? b.level_four.sort    : '0') +
+        (b.level_seven   ? b.level_seven.sort   : '0') +
+        (b.level_ten     ? b.level_ten.sort     : '0') +
+        (b.level_thirteen ? b.level_thirteen.sort : '0') +
+        (b.level_sixteen  ? b.level_sixteen.sort  : '0') +
+        (b.level_twenty   ? b.level_twenty.sort   : '0') +
+        "," + b.hero.build_copy_name + "]";
+    },
+    copyKey(heroName, gt) {
+      return `${heroName}|${gt}`;
+    },
+    copyLabel(heroName, gt) {
+      return this.copiedState[this.copyKey(heroName, gt)] ? 'COPIED' : 'COPY TO CLIPBOARD';
+    },
+    copyColor(heroName, gt) {
+      return this.copiedState[this.copyKey(heroName, gt)] ? 'teal' : 'blue';
+    },
+    copyToClipboard(heroName, gt) {
+      const build = this.firstBuild(heroName, gt);
+      if (!build) return;
+      const key = this.copyKey(heroName, gt);
+      navigator.clipboard.writeText(this.getCopyBuildToGame(build)).then(() => {
+        this.$set(this.copiedState, key, true);
+        setTimeout(() => this.$set(this.copiedState, key, false), 2000);
+      });
+    },
+  },
+}
+</script>

--- a/resources/js/components/Global/Talents/GlobalTalentsStats.vue
+++ b/resources/js/components/Global/Talents/GlobalTalentsStats.vue
@@ -10,7 +10,19 @@
 
     
         <div v-if="!selectedHero">
-          <hero-selection :heroes="heroes"></hero-selection>
+          <div class="flex justify-between max-w-[1500px] mx-auto md:px-4">
+            <hero-selection :heroes="heroes" @search="heroSearchQuery = $event"></hero-selection>
+          </div>
+
+          <dynamic-banner-ad :patreon-user="patreonUser" :index="3" :mobile-override="false"></dynamic-banner-ad>
+
+          <div class="max-w-[1500px] mx-auto md:px-4 mt-8 w-full">
+            <h2 class="heading mb-4">Most Popular Builds for Latest Patch Per Hero and Game Type</h2>
+            <div v-if="!talentbuilddataall" class="text-sm text-gray-400 flex items-center gap-2">
+              <i class="fas fa-spinner fa-spin"></i> Loading all talent builds...
+            </div>
+            <global-talent-builds-all v-else :heroes="filteredHeroesForTable" :talentbuilddataall="talentbuilddataall"></global-talent-builds-all>
+          </div>
         </div>
 
         <div v-else>
@@ -144,6 +156,8 @@
        selectedHero: null,
        talentdetaildata: null,
        talentbuilddata: null,
+       talentbuilddataall: null,
+       heroSearchQuery: "",
        buildtypes: [
         { code: 'Popular', name: 'Popular' },
         { code: 'HP Algorithm', name: 'HP Algorithm' },
@@ -200,9 +214,16 @@
     }
    },
     mounted() {
-
+      if(!this.inputhero){
+        this.getTalentBuildDataAll();
+      }
     },
     computed: {
+      filteredHeroesForTable() {
+        if (!this.heroSearchQuery) return this.heroes;
+        const q = this.heroSearchQuery.normalize("NFD").replace(/[̀-ͯ]/g, "").toLowerCase();
+        return this.heroes.filter(h => h.name.normalize("NFD").replace(/[̀-ͯ]/g, "").toLowerCase().includes(q));
+      },
       patchNotesUrl() {
         if (this.timeframetype !== 'minor' || !this.timeframe || this.timeframe.length !== 1) {
           return null;
@@ -316,6 +337,51 @@
           this.isBuildsLoading = false;
         }
       },
+
+      async getTalentBuildDataAll(){
+        this.dataError = false;
+        this.isBuildsLoading = true;
+
+        if (this.cancelBuildsTokenSource) {
+          this.cancelBuildsTokenSource.cancel('Request canceled');
+        }
+        this.cancelBuildsTokenSource = this.$axios.CancelToken.source();
+
+        try{
+          const response = await this.$globalAsyncPost("/api/v1/global/talents/build/all", {
+            timeframe_type: this.timeframetype,
+            timeframe: this.timeframe,
+            region: this.region,
+            statfilter: this.statfilter,
+            hero_level: this.herolevel,
+            game_type: this.gametype,
+            game_map: this.gamemap,
+            league_tier: this.playerrank,
+            hero_league_tier: this.herorank,
+            role_league_tier: this.rolerank,
+            mirror: this.mirrormatch,
+            talentbuildtype: this.talentbuildtype,
+          },
+          {
+            cancelToken: this.cancelBuildsTokenSource.token,
+          });
+
+          
+          if(response.data.status == "failure to validate inputs"){
+            throw new Error("Failure to validate inputs");
+          }
+          
+          this.talentbuilddataall = response.data;
+
+        }catch(error){
+          this.dataError = true;
+        }finally {
+          this.cancelBuildsTokenSource = null;
+          this.isBuildsLoading = false;
+        }
+      },
+
+
       cancelAxiosRequest() {
         if (this.cancelTalentsTokenSource || this.cancelBuildsTokenSource) {
           this.cancelTalentsTokenSource.cancel('Request canceled by user');
@@ -338,6 +404,7 @@
 
         this.talentdetaildata = null;
         this.talentbuilddata  = null;
+        this.talentbuilddataall  = null;
         this.showPatchNotes = false;
         this.patchNotesContent = null;
         this.patchNotesLoadedVersion = null;

--- a/resources/js/components/HeroSelection.vue
+++ b/resources/js/components/HeroSelection.vue
@@ -3,8 +3,9 @@
     <div class="text-center my-5">
       <input 
         type="text" 
-        v-model="searchQuery" 
-        class="border rounded p-2 text-black" 
+        v-model="searchQuery"
+        @input="$emit('search', searchQuery)"
+        class="border rounded p-2 text-black"
         placeholder="Search for a hero..."
       />
     </div>

--- a/resources/js/components/RoundImage.vue
+++ b/resources/js/components/RoundImage.vue
@@ -70,10 +70,13 @@
         'left-1/2 transform -translate-x-1/2 bottom-[1em] -translate-y-[2em]': tooltipPosition === 'top',
         'bottom-[4.5em] -translate-y-[2em]': tooltipPosition === 'top' && size === 'big',
         'bottom-[6em] -translate-y-[3em]': tooltipPosition === 'top' && size === 'xl',
-        
+
+        // Bottom positioning (when too close to top of viewport)
+        'left-1/2 transform -translate-x-1/2 top-[1em] translate-y-[2em]': tooltipPosition === 'bottom',
+
         // Right positioning (when too close to left edge)
         'left-full top-1/2 -translate-y-1/2 ml-2': tooltipPosition === 'right',
-        
+
         // Left positioning (when too close to right edge)
         'right-full top-1/2 -translate-y-1/2 mr-2': tooltipPosition === 'left',
         
@@ -160,25 +163,25 @@ export default {
     },
     calculateTooltipPosition() {
       if (!this.$refs.container) return;
-      
+
       const rect = this.$refs.container.getBoundingClientRect();
-      const tooltipWidth = this.popupsize === 'large' ? 320 : 192; // 20em or 12em in pixels (approx)
+      const tooltipWidth = this.popupsize === 'large' ? 320 : 192;
+      const tooltipHeight = 120; // approximate height of tooltip popup
       const halfTooltip = tooltipWidth / 2;
       const screenWidth = window.innerWidth;
-      
-      // Check if tooltip would overflow left edge when centered
+
       const leftEdgeWhenCentered = rect.left + (rect.width / 2) - halfTooltip;
-      // Check if tooltip would overflow right edge when centered
       const rightEdgeWhenCentered = rect.left + (rect.width / 2) + halfTooltip;
-      
-      if (leftEdgeWhenCentered < 10) {
-        // Too close to left edge, show tooltip on the right
+      const tooCloseToTop = rect.top < tooltipHeight;
+
+      if (tooCloseToTop) {
+        // Not enough space above — show below instead
+        this.tooltipPosition = 'bottom';
+      } else if (leftEdgeWhenCentered < 10) {
         this.tooltipPosition = 'right';
       } else if (rightEdgeWhenCentered > screenWidth - 10) {
-        // Too close to right edge, show tooltip on the left
         this.tooltipPosition = 'left';
       } else {
-        // Default: show tooltip on top
         this.tooltipPosition = 'top';
       }
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -71,6 +71,7 @@ Route::prefix('v1')->middleware('web')->group(function () {
     Route::post('global/talents/', [GlobalTalentStatsController::class, 'getGlobalHeroTalentData']);
 
     Route::post('global/talents/build', [GlobalTalentStatsController::class, 'getGlobalHeroTalentBuildData']);
+    Route::post('global/talents/build/all', [GlobalTalentStatsController::class, 'getGlobalHeroTalentBuildDataAll']);
 
     Route::post('global/leaderboard', [GlobalLeaderboardController::class, 'getLeaderboardData']);
     Route::post('global/leaderboard/calculate/rating', [GlobalLeaderboardController::class, 'getLeaderboardRating']);


### PR DESCRIPTION
- New /api/v1/global/talents/build/all endpoint iterates per-hero build cache across qm/sl/ar game types and caches the combined result
- New GlobalTalentBuildsAll.vue table shows most popular build per hero per game type with talent icons and copy-to-clipboard
- Hero search in HeroSelection now emits query up to filter the builds table in sync
- Dynamic banner ad added between hero grid and builds table
- RoundImage tooltip repositions below icon when too close to top of viewport